### PR TITLE
Migrate to SvelteKit with install-website from npm

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  FLUID_SCRIPT: node_modules/@explorable-viz/fluid/script
+
 jobs:
   test:
     strategy:
@@ -49,3 +52,24 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: website/article/build
         keep_files: false
+    - name: wait for GitHub Pages deployment
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        DEPLOY_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        LATEST='gh run list --workflow=pages-build-deployment --branch=gh-pages --limit=1'
+
+        ./$FLUID_SCRIPT/util/poll.sh "Waiting for Pages deployment to start..." 30 \
+          "[[ \"\$($LATEST --json createdAt --jq '.[0].createdAt')\" > \"$DEPLOY_TIME\" ]]"
+
+        ./$FLUID_SCRIPT/util/poll.sh "Waiting for Pages deployment to complete..." 60 \
+          "[ \"\$($LATEST --json status --jq '.[0].status')\" = \"completed\" ]"
+
+        CONCLUSION=$($LATEST --json conclusion --jq '.[0].conclusion')
+        echo "Pages deployment: $CONCLUSION"
+        [ "$CONCLUSION" = "success" ] || { echo "Pages deployment failed!" >&2; exit 1; }
+    - name: test deployed website
+      run: |
+        ./$FLUID_SCRIPT/util/install-puppeteer.sh
+        cd website/article
+        ../../$FLUID_SCRIPT/util/run-website-tests.sh https://explorable-viz.github.io/fluid-article

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -22,18 +22,10 @@ jobs:
         npx install-website article
         cd website/article
         yarn install
-    - name: build
-      run: |
-        cd website/article
-        yarn build
     - name: test
       run: |
         cd website/article
-        yarn puppeteer browsers install chrome
-        yarn puppeteer browsers install firefox
-        npx vite preview --port 8080 --host 127.0.0.1 --strictPort &
-        sleep 3
-        node -e "import('./test.mjs').then(({ main }) => main()).then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); })"
+        yarn test
 
   deploy-website:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -16,37 +16,40 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 22
-    - run: |
-        shopt -s extglob nullglob globstar
-      if: runner.os == 'Linux'
-    - name: run-test
+    - name: setup
       run: |
         yarn install
-        yarn install-website article
-        set -x -e
-        yarn bundle-website article
-        export PUPPETEER_CACHE_DIR=$GITHUB_WORKSPACE/
-        # requires Puppeteer to be installed at same version as used in Fluid
-        yarn puppeteer browsers install chrome
-        yarn puppeteer browsers install firefox
-        yarn test-website article
+        npx install-website article
+        cd website/article
+        yarn install
+    - name: build
+      run: |
+        cd website/article
+        yarn build
+    - name: test
+      run: |
+        cd website/article
+        yarn test
 
   deploy-website:
     runs-on: ubuntu-22.04
     needs: test
-    # Use branch 'website' to experiment with deploy-website
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/website'
+    if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
-      - name: build
-        run: |
-          yarn install
-          set -x -e
-          yarn install-website article
-          yarn bundle-website article
-      - name: gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: dist/article
-          keep_files: false
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+    - name: build
+      run: |
+        yarn install
+        npx install-website article
+        cd website/article
+        yarn install
+        yarn build
+    - name: gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: website/article/build
+        keep_files: false

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -52,24 +52,8 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: website/article/build
         keep_files: false
-    - name: wait for GitHub Pages deployment
+    - name: test deployed website
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        DEPLOY_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-        LATEST='gh run list --workflow=pages-build-deployment --branch=gh-pages --limit=1'
-
-        ./$FLUID_SCRIPT/util/poll.sh "Waiting for Pages deployment to start..." 30 \
-          "[[ \"\$($LATEST --json createdAt --jq '.[0].createdAt')\" > \"$DEPLOY_TIME\" ]]"
-
-        ./$FLUID_SCRIPT/util/poll.sh "Waiting for Pages deployment to complete..." 60 \
-          "[ \"\$($LATEST --json status --jq '.[0].status')\" = \"completed\" ]"
-
-        CONCLUSION=$($LATEST --json conclusion --jq '.[0].conclusion')
-        echo "Pages deployment: $CONCLUSION"
-        [ "$CONCLUSION" = "success" ] || { echo "Pages deployment failed!" >&2; exit 1; }
-    - name: test deployed website
-      run: |
-        ./$FLUID_SCRIPT/util/install-puppeteer.sh
-        cd website/article
-        ../../$FLUID_SCRIPT/util/run-website-tests.sh https://explorable-viz.github.io/fluid-article
+        ./$FLUID_SCRIPT/util/test-deployed-website.sh https://explorable-viz.github.io/fluid-article website/article

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -29,7 +29,11 @@ jobs:
     - name: test
       run: |
         cd website/article
-        yarn test
+        yarn puppeteer browsers install chrome
+        yarn puppeteer browsers install firefox
+        npx vite preview --port 8080 --host 127.0.0.1 --strictPort &
+        sleep 3
+        node -e "import('./test.mjs').then(({ main }) => main()).then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); })"
 
   deploy-website:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -1,52 +1,39 @@
-[![develop](https://github.com/explorable-viz/fluid-article/actions/workflows/test-deploy.yml/badge.svg)](https://github.com/explorable-viz/fluid-article/actions/workflows/test-deploy.yml)
+[![test-deploy](https://github.com/explorable-viz/fluid-article/actions/workflows/test-deploy.yml/badge.svg)](https://github.com/explorable-viz/fluid-article/actions/workflows/test-deploy.yml)
 [![GitHub pages](https://github.com/explorable-viz/fluid-article/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/explorable-viz/fluid-article/actions/workflows/pages/pages-build-deployment)
 
 # fluid-article
-Template repo for Fluid article. To create a new online article:
 
-- Create a new repository from this template
-- In the Workflow Permissions settings for the new repo, enable the following for GitHub Actions:
+Template repo for Fluid article websites, built with SvelteKit.
+
+## Creating a new article
+
+1. Create a new repository from this template
+2. In the repo's Workflow Permissions settings, enable:
    - Read and write permissions
    - Create and approve pull requests
-- Once the `test-deploy` workflow has succeeded, go to the Pages settings for the repo and configure GitHub Pages to deploy from the `gh-pages` branch
-- When `pages-build-deployment` completes your website should be live
+3. Once the `test-deploy` workflow succeeds, configure GitHub Pages to deploy from the `gh-pages` branch
 
-## Running website locally
+## Running locally
 
-### Software required
-- git
-- Node.js >=18.0.0
-- yarn >= 1.22
+Requires [Node.js](https://nodejs.org/) >= 22.
 
-Windows users may also require
-- Ubuntu WSL
+```bash
+yarn install
+yarn setup
+cd website/article
+yarn install
+yarn dev
+```
 
-### Installation
+For a production-like preview:
 
-1. Run `yarn install`
-2. Run `yarn install-website article` to copy the example `article` website from `@exploreable-viz/fluid`
+```bash
+yarn build
+yarn preview
+```
 
-### Bundling website
+## Testing
 
-To bundle a website:
-1. Run `yarn bundle-website $WEBSITE_NAME`
-
-This will create a folder in `dist` called `$WEBSITE_NAME`.
-
-### Serving website Locally
-
-To run the website in the browser:
-1. run `npx http-serve dist/$WEBSITE_NAME -a 127.0.0.1 -c-1`
-2. Open browser at localhost
-
-### Running Puppeteer tests
-
-To run your website tests:
-1. Run `yarn test-website $WEBSITE_NAME`
-
-### Convenience commands for single website
-
-If you have a single website called `article`, the following are synonyms for the above:
-- `yarn bundle`
-- `yarn serve`
-- `yarn test`
+```bash
+yarn test
+```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/explorable-viz/fluid/issues"
   },
   "dependencies": {
-    "@explorable-viz/fluid": "0.12.4"
+    "@explorable-viz/fluid": "0.12.5"
   },
   "devDependencies": {
     "puppeteer": "23.11.1"

--- a/package.json
+++ b/package.json
@@ -12,13 +12,6 @@
   "bugs": {
     "url": "https://github.com/explorable-viz/fluid/issues"
   },
-  "scripts": {
-    "setup": "npx install-website article",
-    "dev": "cd website/article && yarn dev",
-    "build": "cd website/article && yarn build",
-    "preview": "cd website/article && yarn preview",
-    "test": "cd website/article && yarn test"
-  },
   "dependencies": {
     "@explorable-viz/fluid": "0.12.4"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/explorable-viz/fluid/issues"
   },
   "dependencies": {
-    "@explorable-viz/fluid": "0.12.8"
+    "@explorable-viz/fluid": "0.12.9"
   },
   "devDependencies": {
     "puppeteer": "23.11.1"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@explorable-viz/fluid-article",
-  "version": "0.1",
-  "description": "Template article for Fluid article.",
+  "version": "0.2",
+  "private": true,
+  "description": "Template for Fluid article websites.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/explorable-viz/fluid.git"
+    "url": "git+https://github.com/explorable-viz/fluid-article.git"
   },
   "author": "Fluid Contributors",
   "license": "MIT",
@@ -12,17 +13,16 @@
     "url": "https://github.com/explorable-viz/fluid/issues"
   },
   "scripts": {
-    "bundle": "yarn bundle-website article",
-    "bundle-serve": "yarn bundle && yarn serve",
-    "serve": "npx http-serve dist/article",
-    "test": "yarn test-website article"
+    "setup": "npx install-website article",
+    "dev": "cd website/article && yarn dev",
+    "build": "cd website/article && yarn build",
+    "preview": "cd website/article && yarn preview",
+    "test": "cd website/article && yarn test"
   },
-  "packageManager": "yarn@1.22.22",
   "dependencies": {
-    "@explorable-viz/fluid": "0.12.2"
+    "@explorable-viz/fluid": "0.12.4"
   },
   "devDependencies": {
-    "puppeteer": "23.11.1",
-    "//": "Set Puppeteer to same version as used by Fluid or risk browser version mismatch"
+    "puppeteer": "23.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/explorable-viz/fluid/issues"
   },
   "dependencies": {
-    "@explorable-viz/fluid": "0.12.6"
+    "@explorable-viz/fluid": "0.12.7"
   },
   "devDependencies": {
     "puppeteer": "23.11.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/explorable-viz/fluid/issues"
   },
   "dependencies": {
-    "@explorable-viz/fluid": "0.12.7"
+    "@explorable-viz/fluid": "0.12.8"
   },
   "devDependencies": {
     "puppeteer": "23.11.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/explorable-viz/fluid/issues"
   },
   "dependencies": {
-    "@explorable-viz/fluid": "0.12.5"
+    "@explorable-viz/fluid": "0.12.6"
   },
   "devDependencies": {
     "puppeteer": "23.11.1"


### PR DESCRIPTION
## Summary
- Use @explorable-viz/fluid@0.12.9 with `npx install-website article`
- SvelteKit build/dev/test workflow
- CI: setup → test → deploy with post-deploy Puppeteer tests
- Shared scripts from npm package (test-website.sh, test-deployed-website.sh)

## Test plan
- [x] CI passes on sveltekit-migration branch (3 consecutive green runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)